### PR TITLE
Re-enable blank issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
See https://github.com/pivotal-cf/.github/issues/3 for the same context in the `pivotal-cf` organization.